### PR TITLE
allow to render input without adornments

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -43,7 +43,7 @@ class Input extends Component {
 
   render() {
     const { getInputProps, loading, downshiftProps } = this.props;
-    const { label, labelProps, disabled, ...inputProps } = getInputProps
+    const { label, labelProps, disabled, noAdornment, ...inputProps } = getInputProps
       ? getInputProps(downshiftProps)
       : {};
 
@@ -53,7 +53,7 @@ class Input extends Component {
 
         <MuiInput
           inputRef={input => (this.input = input)}
-          endAdornment={
+          endAdornment={!noAdornment && (
             <InputAdornment position="end">
               {!disabled &&
                 !!downshiftProps.selectedItem && (
@@ -68,7 +68,7 @@ class Input extends Component {
                 </IconButton>
               )}
             </InputAdornment>
-          }
+          )}
           onFocus={downshiftProps.openMenu}
           {...downshiftProps.getInputProps(inputProps)}
         />

--- a/stories/basic.js
+++ b/stories/basic.js
@@ -16,6 +16,7 @@ storiesOf('Basic', module)
   .add('defaults (empty)', () => <MuiDownshift />)
   .add('items only', () => <StarWarsSelect />)
   .add('disabled', () => <StarWarsSelect getInputProps={() => ({ disabled: true })} />)
+  .add('no adornment', () => <StarWarsSelect getInputProps={() => ({ noAdornment: true })} />)
   .add('loading', () => <StarWarsSelect loading />);
 
 storiesOf('Input', module)


### PR DESCRIPTION
I'd like to have this simple option on getInputProps, because I'm trying to use mui-downshift to choose sequentially several values like gitlab issue filter:

![2018-03-02-202145_721x204_scrot](https://user-images.githubusercontent.com/3134574/36917545-63a041f6-1e57-11e8-9374-92395348fd36.png)

I don't know the bets approach yet, but I think I'll have a full-width Input, and render `MuiDownShift` wth a transparent Input and a smaller width, at the right left position

I can add this example to the stories if it's doable