### PR TITLE
Fix loading marginBottom

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -68,6 +68,7 @@ class Input extends Component {
               position: 'relative',
               bottom: 2,
               height: 2,
+              marginBottom: -2,
             }}
           />
         )}


### PR DESCRIPTION
If I have helperText and loading={true}, the helperText shifts down a bit, so I fixed.