### PR TITLE
Input ref support

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "react-virtualized": "^9.20.1"
   },
   "devDependencies": {
-    "@material-ui/core": "^1.4.2",
-    "@material-ui/icons": "^1.1.0",
+    "@material-ui/core": "^1.5.0",
+    "@material-ui/icons": "^2.0.2",
     "@storybook/addon-actions": "^3.4.8",
     "@storybook/react": "^3.4.8",
     "babel-cli": "^6.26.0",

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,12 @@ class MuiDownshift extends Component {
               focusOnClear={focusOnClear}
               loading={loading}
               downshiftProps={downshiftProps}
-              inputRef={node => (this.inputRef = node)}
+              inputRef={node => {
+                this.inputRef = node;
+                if (this.props.inputRef && typeof this.props.inputRef === 'function') {
+                  this.props.inputRef(node);
+                }
+              }}
             />
 
             <Menu
@@ -85,6 +90,7 @@ MuiDownshift.defaultProps = {
     ) : null; // TODO: should we handle this or require user to implement `getListItem` at this point (`includeFooter` or an array of null/undefined)?
   },
   menuItemCount: 5,
+  inputRef: undefined,
 };
 
 MuiDownshift.propTypes = {
@@ -97,6 +103,7 @@ MuiDownshift.propTypes = {
   getInputProps: PropTypes.func,
   focusOnClear: PropTypes.bool,
   loading: PropTypes.bool,
+  inputRef: PropTypes.func,
 
   // Menu
   getListItem: PropTypes.func,

--- a/stories/basic.js
+++ b/stories/basic.js
@@ -80,6 +80,16 @@ storiesOf('Input', module)
       focusOnClear
       onChange={action('onChange')}
     />
+  ))
+  .add('blurOnSelect (using inputRef)', () => (
+    <StarWarsSelect
+      getInputProps={({ openMenu }) => ({
+        label: 'Star Wars character',
+        placeholder: 'Choose wisely',
+      })}
+      blurOnSelect
+      onChange={action('onChange')}
+    />
   ));
 
 storiesOf('List item', module)

--- a/stories/components/StarWarsSelect.js
+++ b/stories/components/StarWarsSelect.js
@@ -1,10 +1,15 @@
 import React, { Component } from 'react';
 import { all as starwarsNames } from 'starwars-names';
 import MuiDownshift from '../../src';
+import PropTypes from 'prop-types';
 
 const items = starwarsNames.map((label, value) => ({ label, value }));
 
-export default class StarWarsSelect extends Component {
+class StarWarsSelect extends Component {
+  static defaultProps = {
+    blurOnSelect: false,
+  };
+
   state = {
     filteredItems: items,
   };
@@ -13,6 +18,9 @@ export default class StarWarsSelect extends Component {
     if (typeof changes.inputValue === 'string') {
       const filteredItems = items.filter(item => item.label.toLowerCase().includes(changes.inputValue.toLowerCase()));
       this.setState({ filteredItems });
+    }
+    if (this.input && this.props.blurOnSelect) {
+      this.input.blur();
     }
   };
 
@@ -25,7 +33,16 @@ export default class StarWarsSelect extends Component {
         // getListItemKey={rowIndex => filteredItems[rowIndex].value}
         // keyMapper={rowIndex => filteredItems[rowIndex] && filteredItems[rowIndex].label}
         {...this.props}
+        inputRef={node => {
+          this.input = node;
+        }}
       />
     );
   }
 }
+
+StarWarsSelect.propTypes = {
+  blurOnSelect: PropTypes.bool,
+};
+
+export default StarWarsSelect;

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,12 +46,18 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@babel/runtime@^7.0.0-beta.42":
-  version "7.0.0-beta.47"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.47.tgz#273f5e71629e80f6cbcd7507503848615e59f7e0"
+"@babel/runtime@7.0.0-beta.42":
+  version "7.0.0-beta.42"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.42.tgz#352e40c92e0460d3e82f49bd7e79f6cda76f919f"
   dependencies:
     core-js "^2.5.3"
     regenerator-runtime "^0.11.1"
+
+"@babel/runtime@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.56.tgz#cda612dffd5b1719a7b8e91e3040bd6ae64de8b0"
+  dependencies:
+    regenerator-runtime "^0.12.0"
 
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
@@ -85,11 +91,11 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@material-ui/core@^1.4.2":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-1.4.2.tgz#8a1282e985d4922a4d2b4f7e287d8a716a2fc108"
+"@material-ui/core@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-1.5.0.tgz#00884bb4139d98786d05a97803d19426d4afa55d"
   dependencies:
-    "@babel/runtime" "^7.0.0-beta.42"
+    "@babel/runtime" "7.0.0-beta.42"
     "@types/jss" "^9.5.3"
     "@types/react-transition-group" "^2.0.8"
     brcast "^3.0.1"
@@ -111,17 +117,18 @@
     normalize-scroll-left "^0.1.2"
     popper.js "^1.14.1"
     prop-types "^15.6.0"
-    react-event-listener "^0.6.0"
+    react-event-listener "^0.6.2"
     react-jss "^8.1.0"
     react-transition-group "^2.2.1"
-    recompose "^0.27.0"
+    recompose "^0.28.0"
     warning "^4.0.1"
 
-"@material-ui/icons@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-1.1.0.tgz#4d025df7b0ba6ace8d6710079ed76013a4d26595"
+"@material-ui/icons@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-2.0.2.tgz#0150c38cda089ef284e9b4a730dfe6e88a0b5de6"
   dependencies:
-    recompose "^0.26.0 || ^0.27.0"
+    "@babel/runtime" "7.0.0-beta.42"
+    recompose "^0.28.0"
 
 "@storybook/addon-actions@3.4.8", "@storybook/addon-actions@^3.4.8":
   version "3.4.8"
@@ -5760,11 +5767,11 @@ react-error-overlay@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.0.tgz#d198408a85b4070937a98667f500c832f86bd5d4"
 
-react-event-listener@^0.6.0:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.6.1.tgz#41c7a80a66b398c27dd511e22712b02f3d4eccca"
+react-event-listener@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.6.2.tgz#df405e9578be052b77a76e4c3914686637caecff"
   dependencies:
-    "@babel/runtime" "^7.0.0-beta.42"
+    "@babel/runtime" "7.0.0-beta.42"
     prop-types "^15.6.0"
     warning "^4.0.1"
 
@@ -5946,11 +5953,11 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
-"recompose@^0.26.0 || ^0.27.0", recompose@^0.27.0:
-  version "0.27.1"
-  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.27.1.tgz#1a49e931f183634516633bbb4f4edbfd3f38a7ba"
+recompose@^0.28.0:
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.28.2.tgz#19e679227bdf979e0d31b73ffe7ae38c9194f4a7"
   dependencies:
-    babel-runtime "^6.26.0"
+    "@babel/runtime" "7.0.0-beta.56"
     change-emitter "^0.1.2"
     fbjs "^0.8.1"
     hoist-non-react-statics "^2.3.1"
@@ -5997,6 +6004,10 @@ regenerator-runtime@^0.10.5:
 regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
 
 regenerator-transform@^0.10.0:
   version "0.10.1"


### PR DESCRIPTION
Resolves #48 by adding support for a user-specified `inputRef` prop, thereby allowing for additional functionality. This is demoed in the new story [blurOnSelect (using inputRef)](https://github.com/techniq/mui-downshift/compare/master...tgrowden:input-ref-support?expand=1#diff-fc54d942b313053cdbd3cefff677ba75).