### PR TITLE
InputLabel should shrink when startAdornment is not null

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -42,7 +42,7 @@ class Input extends Component {
     return (
       <FormControl disabled={disabled} required={required} error={error} fullWidth>
         {label && (
-          <InputLabel shrink={downshiftProps.isOpen || downshiftProps.inputValue ? true : undefined} {...downshiftProps.getLabelProps()}>
+          <InputLabel shrink={downshiftProps.isOpen || downshiftProps.inputValue || inputProps.startAdornment ? true : undefined} {...downshiftProps.getLabelProps()}>
             {label}
           </InputLabel>
         )}


### PR DESCRIPTION
As captioned. The label should shrink when startAdornment is not null. Otherwise, the label will be overlapped.