### PR TITLE
Support Input Variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Property | Type | Required | Description
 `loading` | Boolean | |  Show loading indicator
 `focusOnClear` | Boolean | |  Focus input after clearing.  See issue #9
 all props available on `downshift` | |  | `itemToString`, `onChange`, `onStateChange`, ...
+`variant` | 'standard', 'filled', 'outlined' | |  MUI input variant.  Default 'standard'
 
 ### Running Storybook
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react-virtualized": "^9.20.1"
   },
   "devDependencies": {
-    "@material-ui/core": "^3.0.1",
+    "@material-ui/core": "^3.9.2",
     "@material-ui/icons": "^3.0.1",
     "@storybook/addon-actions": "^3.4.10",
     "@storybook/react": "^3.4.10",

--- a/src/Input.js
+++ b/src/Input.js
@@ -1,16 +1,37 @@
 import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
 import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import InputLabel from '@material-ui/core/InputLabel';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import MuiInput from '@material-ui/core/Input';
+import FilledInput from '@material-ui/core/FilledInput';
+import OutlinedInput from '@material-ui/core/OutlinedInput';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import IconButton from '@material-ui/core/IconButton';
 import ArrowDropDown from '@material-ui/icons/ArrowDropDown';
 import ArrowDropUp from '@material-ui/icons/ArrowDropUp';
 import Clear from '@material-ui/icons/Clear';
 
+const variantComponent = {
+  standard: MuiInput,
+  filled: FilledInput,
+  outlined: OutlinedInput,
+};
+
 class Input extends Component {
+  constructor(props) {
+    super(props);
+    this.labelRef = React.createRef();
+  }
+
+  componentDidMount() {
+    if (this.props.variant === 'outlined') {
+      this.labelNode = ReactDOM.findDOMNode(this.labelRef.current);
+      this.forceUpdate();
+    }
+  }
+
   handleClearSelection = e => {
     const { downshiftProps, focusOnClear } = this.props;
     downshiftProps.clearSelection();
@@ -34,19 +55,34 @@ class Input extends Component {
   };
 
   render() {
-    const { inputRef, getInputProps, loading, downshiftProps } = this.props;
+    const { inputRef, getInputProps, loading, downshiftProps, variant } = this.props;
     const { label, labelProps, disabled, required, error, helperText, ...inputProps } = getInputProps
-      ? getInputProps({...downshiftProps, inputRef: this.input, handleClearSelection: this.handleClearSelection, handleToggleMenu: this.handleToggleMenu})
+      ? getInputProps({
+          ...downshiftProps,
+          inputRef: this.input,
+          handleClearSelection: this.handleClearSelection,
+          handleToggleMenu: this.handleToggleMenu,
+        })
       : {};
+
+    const shrink = downshiftProps.isOpen || downshiftProps.inputValue || inputProps.startAdornment ? true : undefined;
+    const InputMore = {};
+    if (variant === 'outlined') {
+      if (typeof shrink !== 'undefined') {
+        InputMore.notched = shrink;
+      }
+      InputMore.labelWidth = (this.labelNode && this.labelNode.offsetWidth) || 0;
+    }
+    const InputComponent = variantComponent[variant];
 
     return (
       <FormControl disabled={disabled} required={required} error={error} fullWidth>
         {label && (
-          <InputLabel shrink={downshiftProps.isOpen || downshiftProps.inputValue || inputProps.startAdornment ? true : undefined} {...downshiftProps.getLabelProps()}>
+          <InputLabel ref={this.labelRef} variant={variant} shrink={shrink} {...downshiftProps.getLabelProps()}>
             {label}
           </InputLabel>
         )}
-        <MuiInput
+        <InputComponent
           inputRef={input => {
             this.input = input;
             inputRef && inputRef(input);
@@ -59,7 +95,6 @@ class Input extends Component {
                     <Clear />
                   </IconButton>
                 )}
-
                 <IconButton onClick={this.handleToggleMenu} aria-label="Toggle menu open">
                   {downshiftProps.isOpen ? <ArrowDropUp /> : <ArrowDropDown />}
                 </IconButton>
@@ -67,9 +102,9 @@ class Input extends Component {
             )
           }
           onFocus={downshiftProps.openMenu}
+          {...InputMore}
           {...downshiftProps.getInputProps(inputProps)}
         />
-
         {loading && (
           <LinearProgress
             style={{

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ class MuiDownshift extends Component {
       getInputProps,
       focusOnClear,
       loading,
+      variant,
 
       // Menu
       getListItem,
@@ -51,6 +52,7 @@ class MuiDownshift extends Component {
                   this.props.inputRef(node);
                 }
               }}
+              variant={variant}
             />
 
             <Menu
@@ -91,6 +93,7 @@ MuiDownshift.defaultProps = {
   },
   menuItemCount: 5,
   inputRef: undefined,
+  variant: 'standard',
 };
 
 MuiDownshift.propTypes = {
@@ -104,6 +107,7 @@ MuiDownshift.propTypes = {
   focusOnClear: PropTypes.bool,
   loading: PropTypes.bool,
   inputRef: PropTypes.func,
+  variant: PropTypes.oneOf('standard','filled','outlined'),
 
   // Menu
   getListItem: PropTypes.func,

--- a/stories/basic.js
+++ b/stories/basic.js
@@ -31,14 +31,12 @@ storiesOf('Basic', module)
   .add('without adornments', () => <StarWarsSelect getInputProps={() => ({ endAdornment: null })} />)
   .add('with custom adornments', () => (
     <StarWarsSelect
-      getInputProps={({ isOpen, selectedItem, handleToggleMenu, handleClearSelection }) => ({
+      getInputProps={({ isOpen, selectedItem, handleClearSelection }) => ({
         endAdornment: (
           <InputAdornment position="end">
-            {isOpen ? (
-              <ArrowDropUp color="default" onClick={handleToggleMenu} />
-            ) : (
-              <ArrowDropDown color="default" onClick={handleToggleMenu} />
-            )}
+            <div style={{ pointerEvents: 'none' }}>
+              {isOpen ? <ArrowDropUp color="default" /> : <ArrowDropDown color="default" />}
+            </div>
             {!!selectedItem && (
               <IconButton color="default" onClick={handleClearSelection} aria-label="Clear selection">
                 <Clear />
@@ -47,6 +45,8 @@ storiesOf('Basic', module)
           </InputAdornment>
         ),
       })}
+      focusOnClear
+      onChange={action('onChange')}
     />
   ))
   .add('loading', () => <StarWarsSelect loading />)
@@ -82,6 +82,83 @@ storiesOf('Basic', module)
         label: 'Star Wars character',
         required: true,
       })}
+    />
+  ));
+
+storiesOf('Variants', module)
+  .add('standard', () => (
+    <StarWarsSelect
+      getInputProps={() => ({
+        label: 'Star Wars character',
+        placeholder: 'Choose wisely',
+      })}
+    />
+  ))
+  .add('filled', () => (
+    <StarWarsSelect
+      variant="filled"
+      getInputProps={({ openMenu }) => ({
+        label: 'Star Wars character',
+        placeholder: 'Choose wisely',
+      })}
+      focusOnClear
+      onChange={action('onChange')}
+    />
+  ))
+  .add('outlined', () => (
+    <StarWarsSelect
+      variant="outlined"
+      getInputProps={({ openMenu }) => ({
+        label: 'Star Wars character',
+        placeholder: 'Choose wisely',
+      })}
+      focusOnClear
+      onChange={action('onChange')}
+    />
+  ))
+  .add('outlined with custom adornments', () => (
+    <StarWarsSelect
+      variant="outlined"      
+      getInputProps={({ isOpen, selectedItem, handleToggleMenu, handleClearSelection }) => ({
+        placeholder: 'Choose wisely',
+        endAdornment: (
+          <InputAdornment position="end">
+            <div style={{ pointerEvents: 'none' }}>
+              {isOpen ? <ArrowDropUp color="default" /> : <ArrowDropDown color="default" />}
+            </div>
+            {!!selectedItem && (
+              <IconButton color="default" onClick={handleClearSelection} aria-label="Clear selection">
+                <Clear />
+              </IconButton>
+            )}
+          </InputAdornment>
+        ),        
+      })}
+      focusOnClear
+      onChange={action('onChange')}
+    />
+  ))
+  .add('outlined with custom adornments and label', () => (
+    <StarWarsSelect
+      variant="outlined"
+      getInputProps={({ isOpen, selectedItem, handleToggleMenu, handleClearSelection }) => ({
+        label: 'Star Wars character',
+        placeholder: 'Choose wisely',
+        endAdornment: (
+          <InputAdornment position="end">
+            <div style={{ pointerEvents: 'none' }}>
+              {isOpen ? <ArrowDropUp color="default" /> : <ArrowDropDown color="default" />}
+            </div>
+            {!!selectedItem && (
+              <IconButton color="default" onClick={handleClearSelection} aria-label="Clear selection">
+                <Clear />
+              </IconButton>
+            )}
+          </InputAdornment>
+        ),
+      })}
+      focusOnClear
+      onChange={action('onChange')}
     />
   ));
 


### PR DESCRIPTION
This adds support for filled and outlined MUI Input variants.

Resolves: https://github.com/techniq/mui-downshift/issues/73

Changes Made:

Update Material-UI version, which includes input variant components
Update Input to support different input variant components
Cleanup custom adornment story
Add input variant stories
Add variant prop
Update documentation
