### PR TITLE
Add material-ui to the list of npm keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
     "dist"
   ],
   "main": "dist/index.js",
+  "keywords": [
+    "react",
+    "downshift",
+    "material-ui"
+  ],
   "peerDependencies": {
     "@material-ui/core": "^3.0.0",
     "@material-ui/icons": "^3.0.0",


### PR DESCRIPTION
I would like to enable a third-party component search for Material-UI components like Gatsby is doing it with its plugins page: https://www.gatsbyjs.org/plugins/.